### PR TITLE
Update init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -63,8 +63,6 @@ appSetup () {
 			wins support = yes\\n\
 			template shell = /bin/bash\\n\
 			winbind nss info = rfc2307\\n\
-			idmap config ${URDOMAIN}: range = 10000-20000\\n\
-			idmap config ${URDOMAIN}: backend = ad\
 			" /etc/samba/smb.conf
 		if [[ $DNSFORWARDER != "NONE" ]]; then
 			sed -i "/\[global\]/a \


### PR DESCRIPTION
> ID mapping back ends are not supported in the smb.conf file on a Samba Active Directory (AD) domain controller (DC).
> For details, see Failure To Access Shares on Domain Controllers If idmap config Parameters Set in the smb.conf File.

samba wiki
Let samba handle its default database backend
Has to be modified before first clean start or mapping will be broken resulting in the following error (w10 client). 
`samba security id structure is invalid`
P.S. build was done successfully with aarch64 and current ubuntu branch. But i also got this error in bionic and if i remember right also in xenial.

it may break things if your a not a dc but a member server.