### PR TITLE
Update to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
 MAINTAINER Fmstrat <fmstrat@NOSPAM.NO>
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
This updates the samba package from version 4.3.11 to 4.11.6.

Samba 4.4 contains a fix to support searching for nested AD groups:
https://bugzilla.samba.org/show_bug.cgi?id=10493