### PR TITLE
Fixed security issue with config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN \
 ADD init.sh /init.sh
 ADD domain.sh /domain.sh
 RUN chmod 755 /init.sh /domain.sh
-CMD /init.sh
+CMD [ "/init.sh" ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A well documented, tried and tested Samba Active Directory Domain Controller tha
 * `INSECURELDAP` defaults to `false`. When set to true, it removes the secure LDAP requirement. While this is not recommended for production it is required for some LDAP tools. You can remove it later from the smb.conf file stored in the config directory.
 * `MULTISITE` defaults to `false` and tells the container to connect to an OpenVPN site via an ovpn file with no password. For instance, if you have two locations where you run your domain controllers, they need to be able to interact. The VPN allows them to do that.
 * `NOCOMPLEXITY` defaults to `false`. When set to `true` it removes password complexity requirements including `complexity, history-length, min-pwd-age, max-pwd-age`
+* `LOGLEVEL` can be set to a numeric value (1-10) to override the log level configuration in smb.conf.
 
 ## Volumes for quick start
 * `/etc/localtime:/etc/localtime:ro` - Sets the timezone to match the host

--- a/arm.Dockerfile
+++ b/arm.Dockerfile
@@ -28,4 +28,4 @@ RUN \
 ADD init.sh /init.sh
 ADD domain.sh /domain.sh
 RUN chmod 755 /init.sh /domain.sh
-CMD /init.sh setup
+CMD [ "/init.sh" ]


### PR DESCRIPTION
This PR fixes a security issue with `supervisord`(is logged when used in latest Ubuntu releases). 

Resolved problems:
* Prevent `supervisord` from searching for config files at standard paths by specifying the config to use.
* Create a complete config without unnecessary remote-control interfaces that are initialized when keeping the config from the distribution.
* Finally, tell `supervisord` that running as root is intended and no warning must be logged (after fixing the issues).