### PR TITLE
add ENV `NBDOMAIN` to allow change of the NETBIOS Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A well documented, tried and tested Samba Active Directory Domain Controller tha
 ## Environment variables for quick start
 * `DOMAIN` defaults to `CORP.EXAMPLE.COM` and should be set to your domain
 * `DOMAINPASS` should be set to your administrator password, be it existing or new. This can be removed from the environment after the first setup run.
+* `NBDOMAIN` defaults to the first part of your `DOMAIN`. Set this value to change the _NetBIOS Domain_ of your active directory  
 * `HOSTIP` can be set to the IP you want to advertise.
 * `JOIN` defaults to `false` and means the container will provision a new domain. Set this to `true` to join an existing domain.
 * `JOINSITE` is optional and can be set to a site name when joining a domain, otherwise the default site will be used.

--- a/init.sh
+++ b/init.sh
@@ -7,6 +7,7 @@ appSetup () {
 	# Set variables
 	DOMAIN=${DOMAIN:-SAMDOM.LOCAL}
 	DOMAINPASS=${DOMAINPASS:-youshouldsetapassword}
+	NBDOMAIN=${NBDOMAIN:-NONE}
 	JOIN=${JOIN:-false}
 	JOINSITE=${JOINSITE:-NONE}
 	MULTISITE=${MULTISITE:-false}
@@ -17,7 +18,12 @@ appSetup () {
 	
 	LDOMAIN=${DOMAIN,,}
 	UDOMAIN=${DOMAIN^^}
-	URDOMAIN=${UDOMAIN%%.*}
+
+	if [[ ${NBDOMAIN} == "NONE" ]]; then
+		URDOMAIN=${UDOMAIN%%.*}
+	else
+		URDOMAIN=${NBDOMAIN}
+	fi
 
 	# If multi-site, we need to connect to the VPN before joining the domain
 	if [[ ${MULTISITE,,} == "true" ]]; then


### PR DESCRIPTION
This allows to customize the NETBIOS name of the domain to being forced to use the first part of the FQDN of the domain

CLOSE #39 

Tested locally and works with master and focal baseimage