### PR TITLE
Added required volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN \
     rm -rf /var/lib/{apt,dpkg,cache,log}/ &&\
     rm -fr /tmp/* /var/tmp/*
 
+VOLUME [ "/var/lib/samba", "/etc/samba/external" ]
+
 ADD init.sh /init.sh
 ADD domain.sh /domain.sh
 RUN chmod 755 /init.sh /domain.sh

--- a/arm.Dockerfile
+++ b/arm.Dockerfile
@@ -25,6 +25,8 @@ RUN \
     rm -rf /var/lib/{apt,dpkg,cache,log}/ &&\
     rm -fr /tmp/* /var/tmp/*
 
+VOLUME [ "/var/lib/samba", "/etc/samba/external" ]
+
 ADD init.sh /init.sh
 ADD domain.sh /domain.sh
 RUN chmod 755 /init.sh /domain.sh


### PR DESCRIPTION
Adds required volumes so that the container can run without defining volumes externally (still recommended)