### PR TITLE
Custom workgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A well documented, tried and tested Samba Active Directory Domain Controller tha
 
 ## Environment variables for quick start
 * `DOMAIN` defaults to `CORP.EXAMPLE.COM` and should be set to your domain
+* `WORKGROUP` defaults to `CORP` from `CORP.EXAMPLE.COM` but can be customised
 * `DOMAINPASS` should be set to your administrator password, be it existing or new. This can be removed from the environment after the first setup run.
 * `HOSTIP` can be set to the IP you want to advertise.
 * `JOIN` defaults to `false` and means the container will provision a new domain. Set this to `true` to join an existing domain.

--- a/init.sh
+++ b/init.sh
@@ -18,7 +18,7 @@ appSetup () {
 	
 	LDOMAIN=${DOMAIN,,}
 	UDOMAIN=${DOMAIN^^}
-    URDOMAIN=${WORKGROUP:-${UDOMAIN%%.*}}
+	URDOMAIN=${WORKGROUP:-${UDOMAIN%%.*}}
 
 	# If multi-site, we need to connect to the VPN before joining the domain
 	if [[ ${MULTISITE,,} == "true" ]]; then

--- a/init.sh
+++ b/init.sh
@@ -18,7 +18,7 @@ appSetup () {
 	
 	LDOMAIN=${DOMAIN,,}
 	UDOMAIN=${DOMAIN^^}
-	URDOMAIN=${UDOMAIN%%.*}
+    URDOMAIN=${WORKGROUP:-${UDOMAIN%%.*}}
 
 	# If multi-site, we need to connect to the VPN before joining the domain
 	if [[ ${MULTISITE,,} == "true" ]]; then


### PR DESCRIPTION
Added a WORKGROUP variable to allow customisation.  

Note: I have 0 experience with AD and DC's so maybe what I wanted is not a valid configuration but in my case, I had specified my domain as INT.MYCOMPANY.COM but I didn't want my users to be INT\user.  Instead I would like them to be MYCOMPANY\user.