### PR TITLE
fix: add dnsutils package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
         ldb-tools \
         vim \
         curl \
+        dnsutils \
         ntp &&\
     apt-get clean autoclean &&\
     apt-get autoremove --yes &&\


### PR DESCRIPTION
Added dnsutils package to the Dockerfil to fix the following error repeating in the logs.

dnsupdate_nameupdate_done: Failed DNS update with exit code 5

Now correctly updates the DNS entries