### PR TITLE
Use actual domain name in domain.sh info script

### DIFF
--- a/domain.sh
+++ b/domain.sh
@@ -39,7 +39,7 @@ Usage:
 
 case "${1}" in
 	info)
-		wbinfo -D CORP
+		wbinfo -D "$(wbinfo --own-domain)"
 		;;
 	ldapinfo)
 		ldapsearch -b "${DOMAIN_DC}"


### PR DESCRIPTION
Instead of   hardcoded `CORP` value.

Without this change `./domain.sh info` failed if the domain name was anything other than `CORP`. `wbinfo --own-domain` returns the actual name of the domain.