### PR TITLE
Eliminated LDIF read failure due to incorrect args

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -164,8 +164,8 @@ objectCategory: CN=Class-Schema,CN=Schema,CN=Configuration,${DOMAIN_DC}
 defaultObjectCategory: CN=ldapPublicKey,CN=Schema,CN=Configuration,${DOMAIN_DC}
 mayContain: sshPublicKey
 schemaIDGUID:: +8nFQ43rpkWTOgbCCcSkqA==" > /tmp/Sshpubkey.class.ldif
-	ldbadd -H /var/lib/samba/private/sam.ldb /var/lib/samba/private/sam.ldb /tmp/Sshpubkey.attr.ldif --option="dsdb:schema update allowed"=true
-	ldbadd -H /var/lib/samba/private/sam.ldb /var/lib/samba/private/sam.ldb /tmp/Sshpubkey.class.ldif --option="dsdb:schema update allowed"=true
+	ldbadd -H /var/lib/samba/private/sam.ldb --option="dsdb:schema update allowed"=true /tmp/Sshpubkey.attr.ldif
+	ldbadd -H /var/lib/samba/private/sam.ldb --option="dsdb:schema update allowed"=true /tmp/Sshpubkey.class.ldif
 }
 
 appStart () {


### PR DESCRIPTION
The ldbadd command for Sshpubkey schema specifies the sam.ldb file twice, which `ldbadd` treats as a second LDIF file, which prints an error to the output (because parsing the ldb file as LDIF fails). Also strictly speaking the options should be specified before the LDIF file(s) on the command line. The existing code worked, but this eliminates a spurious error from the output that caused me to waste time troubleshooting.