### PR TITLE
Change DOMAIN_DC  to DOMAIN_DN and make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A well documented, tried and tested Samba Active Directory Domain Controller tha
 
 ## Environment variables for quick start
 * `DOMAIN` defaults to `CORP.EXAMPLE.COM` and should be set to your domain
+* `DOMAIN_DN` is the LDAP path form of your `DOMAIN` (e.g. `DC=CORP,DC=EXAMPLE,DC=COM`) and by default will be computed from the provided `DOMAIN` value.
 * `DOMAINPASS` should be set to your administrator password, be it existing or new. This can be removed from the environment after the first setup run.
 * `HOSTIP` can be set to the IP you want to advertise.
 * `JOIN` defaults to `false` and means the container will provision a new domain. Set this to `true` to join an existing domain.
@@ -113,7 +114,7 @@ Start a new domain, and forward non-resolvable queries to the main DNS server
 ```
 docker run -t -i \
     -e "DOMAIN=CORP.EXAMPLE.COM" \
-    -e "DOMAIN_DC=dc=corp,dc=example,dc=com" \
+    -e "DOMAIN_DN=dc=corp,dc=example,dc=com" \
     -e "DOMAIN_EMAIL=example.com" \
     -e "DOMAINPASS=ThisIsMyAdminPassword^123" \
     -e "DNSFORWARDER=192.168.3.1" \
@@ -157,7 +158,7 @@ Join an existing domain, and forward non-resolvable queries to the main DNS serv
 ```
 docker run -t -i \
     -e "DOMAIN=CORP.EXAMPLE.COM" \
-    -e "DOMAIN_DC=dc=corp,dc=example,dc=com" \
+    -e "DOMAIN_DN=dc=corp,dc=example,dc=com" \
     -e "DOMAIN_EMAIL=example.com" \
     -e "DOMAINPASS=ThisIsMyAdminPassword^123" \
     -e "JOIN=true" \
@@ -205,7 +206,7 @@ Join an existing domain, forward DNS, remove security features, and connect to a
 ```
 docker run -t -i \
     -e "DOMAIN=CORP.EXAMPLE.COM" \
-    -e "DOMAIN_DC=dc=corp,dc=example,dc=com" \
+    -e "DOMAIN_DN=dc=corp,dc=example,dc=com" \
     -e "DOMAIN_EMAIL=example.com" \
     -e "DOMAINPASS=ThisIsMyAdminPassword^123" \
     -e "JOIN=true" \
@@ -280,7 +281,7 @@ services:
       - /data/docker/containers/samba/config/samba:/etc/samba/external
     environment:
       - DOMAIN=CORP.EXAMPLE.COM
-      - DOMAIN_DC=dc=corp,dc=example,dc=com
+      - DOMAIN_DN=dc=corp,dc=example,dc=com
       - DOMAIN_EMAIL=example.com
       - DOMAINPASS=ThisIsMyAdminPassword^123
       - DNSFORWARDER=192.168.3.1
@@ -345,7 +346,7 @@ services:
       - /data/docker/containers/samba/config/samba:/etc/samba/external
     environment:
       - DOMAIN=CORP.EXAMPLE.COM
-      - DOMAIN_DC=dc=corp,dc=example,dc=com
+      - DOMAIN_DN=dc=corp,dc=example,dc=com
       - DOMAIN_EMAIL=example.com
       - DOMAINPASS=ThisIsMyAdminPassword^123
       - JOIN=true
@@ -416,7 +417,7 @@ services:
       - /data/docker/containers/samba/config/openvpn/credentials:/credentials
     environment:
       - DOMAIN=CORP.EXAMPLE.COM
-      - DOMAIN_DC=dc=corp,dc=example,dc=com
+      - DOMAIN_DN=dc=corp,dc=example,dc=com
       - DOMAIN_EMAIL=example.com
       - DOMAINPASS=ThisIsMyAdminPassword^123
       - JOIN=true


### PR DESCRIPTION
The `DOMAIN_DC` env variable was provided in all examples but not documented in the "quick start" instructions, yet it was necessary for setup to run. This change computes the value from `DOMAIN` if it is not explicitly specified, and adds documentation for it. It also changes the name to `DOMAIN_DN` as I think this is a more accurate name than `DOMAIN_DC`, which is ambiguous (it's not necessarily the "root DN", which might technically be "", nor the "search base DN", which is often "OU=Users,DC=corp,...", but it is a DN and it's for the domain...there might be a better name). If `DOMAIN_DN` is not specified but `DOMAIN_DC` _is_, then the value of `DOMAIN_DC` will be used, for backwards-compatibility with existing documentation/examples/deployments.

I've added documentation for it, but notably I'm not sure what the impact is if something is specified for the DN-style domain that doesn't match the DNS-style domain (e.g. `DOMAIN=CORP.EXAMPLE.COM` + `DOMAIN_DN=DC=DOMAIN,DC=EXAMPLE,DC=COM` ... Samba may assume somewhere that these two match (or may not). In any case, the existing code allowed a mismatch, so this new code does not prevent it.