### PR TITLE
Allow specification of which interfaces to bind to

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A well documented, tried and tested Samba Active Directory Domain Controller tha
 * `DOMAIN` defaults to `CORP.EXAMPLE.COM` and should be set to your domain
 * `DOMAINPASS` should be set to your administrator password, be it existing or new. This can be removed from the environment after the first setup run.
 * `HOSTIP` can be set to the IP you want to advertise.
+* `BINDINTERFACES` Specify specific addresses or interfaces that Samba will bind to, in the case that the container has multiple networks attached. The default is `${HOSTIP} lo` and usually will not need to be changed (always include `lo`!). Besides affecting the port listening behavior, this can affect what IPs Samba will register for itself in DNS. Explicitly specify `false` to omit any interface configuration directives (Samba will use all available interfaces). See Samba documentation on `interfaces` directive in smb.conf. 
 * `JOIN` defaults to `false` and means the container will provision a new domain. Set this to `true` to join an existing domain.
 * `JOINSITE` is optional and can be set to a site name when joining a domain, otherwise the default site will be used.
 * `DNSFORWARDER` is optional and if an IP such as `192.168.0.1` is supplied will forward all DNS requests samba can't resolve to that DNS server

--- a/init.sh
+++ b/init.sh
@@ -19,6 +19,7 @@ appSetup () {
 	LDOMAIN=${DOMAIN,,}
 	UDOMAIN=${DOMAIN^^}
 	URDOMAIN=${UDOMAIN%%.*}
+	BINDINTERFACES=${BINDINTERFACES:-${HOSTIP} lo} # specify "false" to add no settings!
 
 	# If multi-site, we need to connect to the VPN before joining the domain
 	if [[ ${MULTISITE,,} == "true" ]]; then
@@ -35,6 +36,16 @@ appSetup () {
 		HOSTIP_OPTION=""
 	fi
 
+	# Set interfaces options
+	if [[ "${BINDINTERFACES}" != "false" ]]; then
+		BINDINTERFACES_OPTIONS=(
+			--option="bind interfaces only = yes"
+			--option="interfaces = ${BINDINTERFACES}"
+		)
+	else
+		BINDINTERFACES_OPTIONS=()
+	fi
+
 	# Set up samba
 	mv /etc/krb5.conf /etc/krb5.conf.orig
 	echo "[libdefaults]" > /etc/krb5.conf
@@ -48,12 +59,12 @@ appSetup () {
 		mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
 		if [[ ${JOIN,,} == "true" ]]; then
 			if [[ ${JOINSITE} == "NONE" ]]; then
-				samba-tool domain join ${LDOMAIN} DC -U"${URDOMAIN}\administrator" --password="${DOMAINPASS}" --dns-backend=SAMBA_INTERNAL
+				samba-tool domain join ${LDOMAIN} DC -U"${URDOMAIN}\administrator" --password="${DOMAINPASS}" --dns-backend=SAMBA_INTERNAL "${BINDINTERFACES_OPTIONS[@]}"
 			else
-				samba-tool domain join ${LDOMAIN} DC -U"${URDOMAIN}\administrator" --password="${DOMAINPASS}" --dns-backend=SAMBA_INTERNAL --site=${JOINSITE}
+				samba-tool domain join ${LDOMAIN} DC -U"${URDOMAIN}\administrator" --password="${DOMAINPASS}" --dns-backend=SAMBA_INTERNAL "${BINDINTERFACES_OPTIONS[@]}" --site=${JOINSITE}
 			fi
 		else
-			samba-tool domain provision --use-rfc2307 --domain=${URDOMAIN} --realm=${UDOMAIN} --server-role=dc --dns-backend=SAMBA_INTERNAL --adminpass=${DOMAINPASS} ${HOSTIP_OPTION}
+			samba-tool domain provision --use-rfc2307 --domain=${URDOMAIN} --realm=${UDOMAIN} --server-role=dc --dns-backend=SAMBA_INTERNAL --adminpass=${DOMAINPASS} ${HOSTIP_OPTION} "${BINDINTERFACES_OPTIONS[@]}"
 			if [[ ${NOCOMPLEXITY,,} == "true" ]]; then
 				samba-tool domain passwordsettings set --complexity=off
 				samba-tool domain passwordsettings set --history-length=0


### PR DESCRIPTION
In cases where the container has multiple interfaces/multiple IPs, it may be necessary to specify which interfaces Samba should use. In my case (microk8s+multus) it was listening additionally on a k8s-internal IP address and _registering that IP address in DNS_, which clients on the LAN would not be able to reach. This change allows specification of an environment variable `BINDINTERFACES` that becomes the `interfaces` value in smb.conf. The default is `${HOSTIP} lo` which excluded any IPs other than the HOSTIP value.

This is a change from previous behavior, where all interfaces would be used, but this new behavior is probably desirable. The old behavior can be preserved by providing `false` explicitly in `BINDINTERFACES`.